### PR TITLE
Datetime bug

### DIFF
--- a/flaskutils/utils.py
+++ b/flaskutils/utils.py
@@ -10,7 +10,7 @@ def string_to_datetime(strdate):
     DATETIME_FORMAT by default '%Y-%m-%d %H:%M:%S'
     this format can be overide in the app configuration settings
     """
-    return datetime.strptime(strdate, app.config['DATETIME_FORMAT'])
+    return datetime.strptime(strdate[:19], app.config['DATETIME_FORMAT'])
 
 
 def string_to_date(strdate):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='flaskutils',
-    version='1.1.0',
+    version='1.1.1',
     description='Flask Utilities',
     packages=['flaskutils', 'flaskutils.commands_flaskutils'],
     author='Manuel Ignacio Franco Galeano',


### PR DESCRIPTION
#@maigfrga @cormacp 

This is a workaround for a problem I've encountered converting strings to datetimes. The current implementation works fine as long as the string is in the form `YYYY-MM-DD HH:MM:SS` e.g. `2017-05-10 16:43:53`

However, if the string is in a format where microseconds or timezone are included e.g. `2017-05-10 16:43:53.197842+00:00`, then the method throws a Value error: `ValueError: unconverted data remains: .197842+00:00`

This MR limits the length of the string to 19 characters, the length of `YYYY-MM-DD HH:MM:SS`, which prevents the error being thrown but there might be a much better way to do this so I'm open to ideas if you have any.
