### PR TITLE
test expression

### DIFF
--- a/flaskutils/commands_flaskutils/test.py
+++ b/flaskutils/commands_flaskutils/test.py
@@ -7,7 +7,10 @@ def run(**kwargs):
     app = kwargs['app']
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--q', help='config file path', required=False,
+        '--q', help='test file path', required=False,
         default=os.path.join(app.config['BASE_DIR'], 'tests'))
+    parser.add_argument(
+        '--x', help='regex for tests to be run', required=False,
+        default='test_')
     args, extra_params = parser.parse_known_args()
-    exit(pytest.main(['-s', args.q]))
+    exit(pytest.main(['-s', args.q, '-k', args.x]))


### PR DESCRIPTION
@maigfrga @cormacp @Rondineli @vcali 

allows expression to be passed to test command to run specific test or tests
e.g. `python3 manage.py test --x test_get_artist_valid`

https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name
